### PR TITLE
Add asserts to code

### DIFF
--- a/src/main/java/chirp/actions/AddAction.java
+++ b/src/main/java/chirp/actions/AddAction.java
@@ -44,7 +44,8 @@ public class AddAction extends Action {
             task = new Event(description, startTime, endTime);
         }
         default -> {
-            throw new ChirpException("Unknown Error!");
+            // This should not happen and is a code bug
+            assert (false) : "Non task command passed to AddAction";
         }
         }
     }

--- a/src/main/java/chirp/actions/MarkAction.java
+++ b/src/main/java/chirp/actions/MarkAction.java
@@ -24,6 +24,7 @@ public class MarkAction extends Action {
         Scanner inputSc = new Scanner(input);
         inputSc.next();
         index = inputSc.nextInt() - 1;
+        assert(command == Command.MARK || command == Command.UNMARK) : "Invalid command passed to MarkAction";
         isDone = command == Command.MARK;
     }
 


### PR DESCRIPTION
Currently there are some control flows in the code that operate under certain assumptions without verifying those assumptions. This can cause unnoticed or unhandled bugs if use improperly.

Asserts are added to these control flow to verify these assumptions. If the assumption does not hold an error message will be displayed. This will notify users of what is being done incorrectly.